### PR TITLE
Fix pawn movement logic and tests

### DIFF
--- a/src/main/java/com/redsky/project/chess/domains/pieces/Pawn.java
+++ b/src/main/java/com/redsky/project/chess/domains/pieces/Pawn.java
@@ -24,15 +24,15 @@ public class Pawn extends Piece {
 		// up the board. Used as a multiplier to reverse the direction.
 		int direction = this.getColor().equals(COLOR.WHITE) ? 1 : -1;
 
-		if (board.spaceIsOccupied(this.getX(), this.getY() + (1 * direction)) == false) {
-			possibleMoves.add(new Coordinates(this.getX(), this.getY() + (1 * direction)));
-			if (this.firstMoveAvailable == true) {
-				if (board.spaceIsOccupied(this.getX(), this.getY() + (1 * direction)) == false) {
-					possibleMoves.add(new Coordinates(this.getX(), this.getY() + (2 * direction)));
-				}
-			}
+                if (board.spaceIsOccupied(this.getX(), this.getY() + (1 * direction)) == false) {
+                        possibleMoves.add(new Coordinates(this.getX(), this.getY() + (1 * direction)));
+                        if (this.firstMoveAvailable == true) {
+                                if (board.spaceIsOccupied(this.getX(), this.getY() + (2 * direction)) == false) {
+                                        possibleMoves.add(new Coordinates(this.getX(), this.getY() + (2 * direction)));
+                                }
+                        }
 
-		}
+                }
 		return possibleMoves;
 	}
 
@@ -46,9 +46,8 @@ public class Pawn extends Piece {
 				int pieceX = this.getX();
 				int pieceY = this.getY();
 
-				if (Math.abs(pieceY - y) == 2) {
-					this.firstMoveAvailable = false;
-				}
+                                // After the first successful move the pawn can no longer move two squares
+                                this.firstMoveAvailable = false;
 
 				Piece[][] boardPieces = board.getBoardPieces();
 				boardPieces[x][y] = board.getBoardPieces()[pieceX][pieceY];

--- a/src/test/java/com/redsky/project/board/BoardTests.java
+++ b/src/test/java/com/redsky/project/board/BoardTests.java
@@ -61,12 +61,12 @@ public class BoardTests {
 		assertEquals(expected, actual);
 	}
 
-	@Test
-	public void testBoardBoundriesY2High() {
-		String expected = STATUS.DESTINATION_NOT_ON_BOARD;
-		String actual = board.movePiece(1, 1, 1, 0);
-		assertEquals(expected, actual);
-	}
+        @Test
+        public void testBoardBoundriesY2High() {
+                String expected = STATUS.DESTINATION_NOT_ON_BOARD;
+                String actual = board.movePiece(1, 1, 1, 9);
+                assertEquals(expected, actual);
+        }
 
 	@Test
 	public void testBoardBoundriesY2Low() {

--- a/src/test/java/com/redsky/project/pieces/PawnTests.java
+++ b/src/test/java/com/redsky/project/pieces/PawnTests.java
@@ -49,11 +49,18 @@ public class PawnTests {
 		assertEquals("Your Pawn cannot move to the locaion of 1, 5.", status);
 	}
 
-	@Test
-	public void testMovePawn_twoForwardSecondMove() {
-		board.movePiece(1, 2, 1, 4);
-		String status = board.movePiece(1, 4, 1, 6);
-		assertEquals("Your Pawn cannot move to the locaion of 1, 6.", status);
-	}
+        @Test
+        public void testMovePawn_twoForwardSecondMove() {
+                board.movePiece(1, 2, 1, 4);
+                String status = board.movePiece(1, 4, 1, 6);
+                assertEquals("Your Pawn cannot move to the locaion of 1, 6.", status);
+        }
+
+        @Test
+        public void testMovePawn_twoForwardAfterSingleStep() {
+                board.movePiece(1, 2, 1, 3);
+                String status = board.movePiece(1, 3, 1, 5);
+                assertEquals("Your Pawn cannot move to the locaion of 1, 5.", status);
+        }
 
 }


### PR DESCRIPTION
## Summary
- ensure pawn double-step check looks at correct destination
- mark pawn first move as used after any move
- correct board boundary test for Y2 high value
- add regression test for pawn double-step after single move

## Testing
- `sh mvnw -q test` *(fails: Could not find MavenWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_684651b353808323b8fcaf2245c95ba8